### PR TITLE
[grunt] Make browserify/watchify work with watch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,12 @@ var grunt = function(grunt) {
       options: {
         livereload: true,
       },
+      configFiles: {
+        files: [ 'Gruntfile.js', 'config/*.js' ],
+        options: {
+          reload: true
+        }
+      },
       scripts: {
         files: serverJSFiles,
         tasks: 'jshint',
@@ -35,6 +41,14 @@ var grunt = function(grunt) {
         options: {
           spawn: false,
         },
+      },
+      browserify: {
+        files: ['client/scripts/index.js'],
+        tasks: [],
+      },
+      concat: {
+        files: ['public/js/client.js'],
+        tasks: ['concat'],
       },
     },
     jshint: {
@@ -65,21 +79,29 @@ var grunt = function(grunt) {
       },
     },
     browserify: {
-      dev: {
-        files: {
-          'public/js/index.js': [
-            'client/scripts/index.js'
-          ],
-        },
+      vendor: {
+        src: [],
+        dest: 'public/js/vendor.js',
         options: {
           transform: ['reactify'],
           require: [
             'react',
             'react-bootstrap'
           ],
+        },
+      },
+      client: {
+        src: ['client/scripts/index.js'],
+        dest: 'public/js/client.js',
+        options: {
+          transform: ['reactify'],
+          external: ['react', 'react-bootstrap'],
           watch: true,
         },
-      }
+      },
+    },
+    concat: {
+      'public/js/index.js': ['public/js/vendor.js', 'public/js/client.js']
     },
   });
 
@@ -88,20 +110,15 @@ var grunt = function(grunt) {
   });
 
   grunt.registerTask('serve', [
-    'browserify:dev',
+    'browserify:vendor',
+    'browserify:client',
     'express:dev',
     'open',
-    'watch:express',
-    'watch:jshint'
+    'watch',
   ]);
 
   //Default task needs to be defined, but for now, it does the same thing as grunt serve.
-  grunt.registerTask('default', [
-    'express:dev',
-    'open',
-    'watch:express',
-    'watch:jshint'
-  ]);
+  grunt.registerTask('default', ['serve']);
 };
 
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "connect-livereload": "^0.5.2",
     "grunt": "^0.4.5",
     "grunt-browserify": "^3.2.1",
+    "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-express-server": "^0.4.19",

--- a/server.js
+++ b/server.js
@@ -58,7 +58,8 @@ var server = function(err) {
   var isProd = app.get('env') === 'production';
 
   // live reload, only on dev mode
-  if (isProd) {
+  if (!isProd) {
+    console.log('Using live reload');
     app.use(require('connect-livereload')());
   }
 


### PR DESCRIPTION
Browserify with watch (which invokes watchify) wasn't working before. It has to be configured a specific way in order for watch to work with  watchify. (Also, jshint wasn't running before.)

This PR fixes both problems.